### PR TITLE
Corrected Readme link on Thomspon Groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ Their generalization to n dimensions are also interesting, but not easy to deal 
 Algorithms and math background: see the
 [poster about this project [PDF]](http://www.math.tamu.edu/~romwell/slides_posters/nvTrees_Paris_2015_Poster.pdf).
 
-For a general introduction to Thompson groups, see [CFP](http://www.math.binghamton.edu/matt/thompson/cfp.pdf). 
+For a general introduction to Thompson groups, see [CFP](http://people.math.binghamton.edu/matt/thompson/cfp.pdf). 
 The program uses a notation compatible with the examples of that paper.


### PR DESCRIPTION
Binghamton's url structure for Matt Brin's site hosting the paper by Cannon, Floyd and Parry has updated, fixing the link